### PR TITLE
change: コードを変更したので参照箇所を追従する

### DIFF
--- a/articles/a0f612677b658b.md
+++ b/articles/a0f612677b658b.md
@@ -154,13 +154,9 @@ flowchart TD
 
 ## コードを読み進める上で
 
-`std::str::FromStr` や `TryFrom` / `TryInto` を含め全ての Result::Err の型は `Box<dyn std::error::Error + Send + Sync + 'static>` にしていますが、都度記述するのは大変なので `lib` クレートで Error と Result の型を定義しています。
+`Id<T>` 構造体を定義して集約やイベントの ID として使っています。
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/lib/src/lib.rs#L1-L2
-
-また、`Id<T>` 構造体を定義して集約やイベントの ID として使っています。
-
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/kernel/src/lib.rs#L15-L18
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/kernel/src/lib.rs#L15-L18
 
 ## kernel
 
@@ -168,25 +164,11 @@ https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a
 
 集約はドメインロジックを定義するほかにコマンドを処理する役割を持ちます。コマンドとはシステムを変更する操作を表していて、1つ以上のイベントから構成されます。例えば部品 (Widget) を作成する `CreateWidget` コマンドを実行すると `WidgetCreated` というイベントが発生するといった具合です。イベントはこれまで説明してきたようにデータの操作を表しています。
 
-### イベント
-
-`WidgetEvent` はデータ操作のイベントを表現する列挙体です。
-
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/kernel/src/event.rs#L5-L29
-
-`WidgetEvent` には
-
-- `WidgetCreated`: 部品を作成するイベント
-- `WidgetNameChanged`: 部品の名前を変更するイベント
-- `WidgetDescriptionChanged`: 部品の説明を変更するイベント
-
-が定義され、それぞれのイベントにはイベント自身の ID ( `id` ) とイベントによって部品の要素 (名前や説明) をどう変化させるかの値を持っています。
-
 ### コマンド
 
 `WidgetCommand` は部品に対してどのような操作をするかを表します。
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/kernel/src/command.rs#L6-L13
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/kernel/src/command.rs#L3-L13
 
 `WidgetCommand` には
 
@@ -194,26 +176,29 @@ https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a
 - `ChangeWidgetName`: 部品の名前を変更するコマンド
 - `ChangeWidgetDescription`: 部品の説明を変更するコマンド
 
-が定義され、それぞれ1つのイベント ( `WidgetEvent` ) から構成されます。1コマンドで複数のイベントが発生する場合は下記のように定義します。
+が定義されています。それぞれのコマンドは集約をどう変化させるかの値を持っています。
 
-```diff rust
-pub enum WidgetCommand {
-    /// 部品を新しく作成する
-    CreateWidget(WidgetEvent),
-    /// 部品の名前を変更する
-    ChangeWidgetName(WidgetEvent),
-    /// 部品の説明を変更する
-    ChangeWidgetDescription(WidgetEvent),
-    /// 複数のイベントが発生するコマンド
-+   DoSomething(Vec<WidgetEvent>),
-}
-```
+### イベント
+
+`WidgetEvent` はデータ操作のイベントを表現する列挙体です。
+
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/kernel/src/event.rs#L5-L30
+
+`WidgetEvent` には
+
+- `WidgetCreated`: 部品を作成するイベント
+- `WidgetNameChanged`: 部品の名前を変更するイベント
+- `WidgetDescriptionChanged`: 部品の説明を変更するイベント
+
+が定義され、それぞれのイベントはコマンドから変換されて永続化されます。
+
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/kernel/src/event.rs#L32-L55
 
 ### 集約
 
 実装したアプリケーションでは集約を `WidgetAggregate` という構造体で表現しました。
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/kernel/src/aggregate.rs#L10-L15
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/kernel/src/aggregate.rs#L7-L13
 
 `WidgetAggregate` は集約自身の ID ( `id` ) と部品の名前 ( `name` )、部品の説明 ( `description` ) 、そして集約の更新回数を表す `version` をフィールドに持っています。`version` フィールドは同時接続などによって競合状態を避けるために使われます。また、不用意に変更されないようフィールドを非公開状態にして関数で値を取得するようにしています。
 
@@ -235,9 +220,9 @@ sequenceDiagram
 
 [Amazon DynamoDB を使った CQRS イベントストアの構築](https://aws.amazon.com/jp/blogs/news/build-a-cqrs-event-store-with-amazon-dynamodb/) の「集約読み込みのアルゴリズム」ではイベントの永続化の言及がありますがその話は後ほど説明するとして、ここでは `adapter` でテーブルから取得したイベントのリストから集約を復元する説明をします。
 
-と言ってもイベントから集約の状態を復元する役割をもつ `WidgetAggregateState` 構造体は集約 ( `aggregate` ) とイベントのリスト ( `events` ) 、集約の ID ( `widget_id` ) 、集約の更新回数 ( `aggregate_version` ) で初期化された後に `restore` 関数を呼び出して `aggregate` の値を `events` を適用して変更した結果の集約を返すだけです。
+と言っても `WidgetAggregate::load_events` 関数にイベントのリストを渡して集約の値をイベントに応じて変更することで集約を復元しています。
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/kernel/src/aggregate.rs#L206-L258
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/kernel/src/aggregate.rs#L54-L86
 
 #### 集約にコマンドを適用する
 
@@ -253,17 +238,17 @@ sequenceDiagram
 
 集約の `apply_command` 関数は引数に受け取ったコマンドを適用しますが、その際に変更される値のバリデーションチェックやビジネスロジックの確認をします。
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/kernel/src/aggregate.rs#L39-L43
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/kernel/src/aggregate.rs#L44-L51
 
-処理全てを `apply_command` 関数内に記述してもいいですが今回は [RustのちょっとやりすぎなBuilderパターン](https://keens.github.io/blog/2017/02/09/rustnochottoyarisuginabuilderpata_n/) を参考に構造体に Generics を定義して、まずコマンドに含まれるイベントの正当性を確認してから順不同で部品名や説明の値をバリデーションチェックするようにしています。
+処理全てを `apply_command` 関数内に記述してもいいですが今回は [RustのちょっとやりすぎなBuilderパターン](https://keens.github.io/blog/2017/02/09/rustnochottoyarisuginabuilderpata_n/) を参考に構造体に Generics を定義して、部品名や説明の値をバリデーションチェックするようにしています。Generics を利用することで、今後バリデーションやビジネスロジックの確認をする際に容易に変更できます。
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/kernel/src/aggregate.rs#L73-L204
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/kernel/src/aggregate.rs#L88-L191
 
 ### Repository のインターフェイス
 
 Repository のインターフェイスは 集約の作成/集約の復元/集約の更新 の3つのみです。
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/kernel/src/processor.rs#L7-L23
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/kernel/src/processor.rs#L6-L22
 
 ## app
 
@@ -284,7 +269,7 @@ sequenceDiagram
     Repository-->>-Service: Result
 ```
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/app/src/lib.rs#L75-L88
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/app/src/lib.rs#L80-L94
 
 部品の名前や説明の変更時は復元された集約に対してコマンドを実行して集約を更新します。`change_widget_name` / `change_widget_description` 関数は同時接続によって他のユーザーが集約を更新していた場合に最大3回、集約の復元からやり直して集約の更新を試みるように実装しました。
 
@@ -309,7 +294,7 @@ sequenceDiagram
     end
 ```
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/app/src/lib.rs#L90-L145
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/app/src/lib.rs#L96-L155
 
 ## adapter
 
@@ -321,11 +306,11 @@ https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a
 
 集約 ( `Aggregate` ) テーブル:
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/migrations/20240210132634_create_aggregate.sql
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/migrations/20240210132634_create_aggregate.sql
 
 イベント ( `Event` ) テーブル:
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/migrations/20240210132646_create_event.sql
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/migrations/20240210132646_create_event.sql
 
 Aggregate テーブルのレコードは集約の ID ( `widget_id` ) と更新回数 ( `aggregate_version` )、そして集約に発生したイベントのリスト ( `last_events` ) で保持します。`last_events` は JSON 形式で表され、例えば部品を作成するイベントが発生した時は
 
@@ -359,9 +344,9 @@ sequenceDiagram
     Repository-->>-Service: Result
 ```
 
-集約を作成する処理 ( `create_widget_aggregate` 関数) は至ってシンプルで、引数で受け取った `CommandState` をそのまま Aggregate テーブルに保存します。
+集約を作成する処理 ( `create_widget_aggregate` 関数) は至ってシンプルで、引数で受け取った `CommandState` を Aggregate テーブルのモデルに変換して保存します。
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/adapter/src/repository.rs#L21-L37
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/adapter/src/repository.rs#L21-L44
 
 ### 集約を更新する処理
 
@@ -383,9 +368,9 @@ sequenceDiagram
     end
 ```
 
-集約を更新する処理 ( `update_widget_aggregate` 関数) も集約を作成する処理と似たように引数で受け取った `CommandState` をそのまま Aggregate テーブルに保存します。
+集約を更新する処理 ( `update_widget_aggregate` 関数) も集約を作成する処理と似たように引数で受け取った `CommandState` を Aggregate テーブルのモデルに変換して保存します。
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/adapter/src/repository.rs#L110-L138
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/adapter/src/repository.rs#L118-L153
 
 集約を作成する処理と違う点は、同時接続によって Aggregate テーブルに保存する集約が競合しないように UPDATE 文の WHERE 句で1つ前の `aggregate_version` を指定していることです。これは楽観ロックと呼ばれる排他制御の手法で、別のユーザーによって既に集約が更新されていた場合は更新対象のレコードが見つからないため更新を防ぐことができます。
 
@@ -421,7 +406,7 @@ sequenceDiagram
 
 注目すべきは「2. 取得した Aggregate テーブルのレコードデータの `last_events` にあるイベントのリストを Event テーブルに保存する」の部分ですが、集約の作成や更新の処理でイベントを永続化するのではなく復元する段階で Event テーブルに永続化します。正直なところ未だに納得できていませんが、同時接続によって Event テーブルに永続化されるイベントの順番を保証したり、イベントの永続化を復元処理の1関数に留めることを目的としているのだと思います。(知っている方がいればコメントで教えてください)
 
-https://github.com/pyama2000/example-cqrs-event-store/blob/5644e19eb328e8dc4e82a2489dc475af0d084ba2/internal/adapter/src/repository.rs#L39-L108
+https://github.com/pyama2000/example-cqrs-event-store/blob/dfe4d11fd92c45a2c57af0a2bb4cc3b691924e96/internal/adapter/src/repository.rs#L46-L116
 
 # アプリケーションの使い方
 

--- a/articles/a0f612677b658b.md
+++ b/articles/a0f612677b658b.md
@@ -6,6 +6,11 @@ topics: ["rust", "eventsourcing", "cqrs"]
 published: true
 ---
 
+:::details Changelog
+**#1**
+https://github.com/pyama2000/zenn/pull/1
+:::
+
 数年前に CQRS (コマンドクエリ責務分離) を知り、調べているときに AWS のブログで [Amazon DynamoDB を使った CQRS イベントストアの構築](https://aws.amazon.com/jp/blogs/news/build-a-cqrs-event-store-with-amazon-dynamodb/) を読む機会がありました。最初は記事を読み進めても処理の流れやコードのイメージが全く湧かなかったのですが数回読んで少し理解できたので、感覚を忘れないうちに実装してみました。なぜ Rust で実装したかというと久しぶりに Rust でアプリケーションを作りたかったからです。
 また、 [Amazon DynamoDB を使った CQRS イベントストアの構築](https://aws.amazon.com/jp/blogs/news/build-a-cqrs-event-store-with-amazon-dynamodb/) ではデータストアに DynamoDB を使っていますが、私は DynamoDB を使ったことがないので MySQL を利用して実装しました。
 

--- a/articles/a0f612677b658b.md
+++ b/articles/a0f612677b658b.md
@@ -34,39 +34,39 @@ CRUD による State Sourcing ではユーザーの操作をデータの作成�
 
 1. 商品 A を1つカートに追加する
 
-   | USER ID   | ITEM ID | NUM |
-   | --------- | ------- | --- |
-   | pyama2000 | A       | 1   |
+   | USER ID   | ITEM ID | QUANTITY |
+   | --------- | ------- | -------- |
+   | pyama2000 | A       | 1        |
 
 2. 商品 B を1つカートに追加する
 
-   | USER ID   | ITEM ID | NUM |
-   | --------- | ------- | --- |
-   | pyama2000 | A       | 1   |
-   | pyama2000 | B       | 2   |
+   | USER ID   | ITEM ID | QUANTITY |
+   | --------- | ------- | -------- |
+   | pyama2000 | A       | 1        |
+   | pyama2000 | B       | 2        |
 
 3. 商品 C を1つカートに追加する
 
-   | USER ID   | ITEM ID | NUM |
-   | --------- | ------- | --- |
-   | pyama2000 | A       | 1   |
-   | pyama2000 | B       | 1   |
-   | pyama2000 | C       | 3   |
+   | USER ID   | ITEM ID | QUANTITY |
+   | --------- | ------- | -------- |
+   | pyama2000 | A       | 1        |
+   | pyama2000 | B       | 1        |
+   | pyama2000 | C       | 3        |
 
 4. 商品 A の注文数を5つに増やす
 
-   | USER ID   | ITEM ID | NUM |
-   | --------- | ------- | --- |
-   | pyama2000 | A       | 5   |
-   | pyama2000 | B       | 2   |
-   | pyama2000 | C       | 3   |
+   | USER ID   | ITEM ID | QUANTITY |
+   | --------- | ------- | -------- |
+   | pyama2000 | A       | 5        |
+   | pyama2000 | B       | 2        |
+   | pyama2000 | C       | 3        |
 
 5. 商品 C をカートから削除する
 
-   | USER ID   | ITEM ID | NUM |
-   | --------- | ------- | --- |
-   | pyama2000 | A       | 5   |
-   | pyama2000 | B       | 2   |
+   | USER ID   | ITEM ID | QUANTITY |
+   | --------- | ------- | -------- |
+   | pyama2000 | A       | 5        |
+   | pyama2000 | B       | 2        |
 
 もちろん State Sourcing でも問題なくカートの状態を表現できますが最終的なカートの中身しか記録されません。こうなるとユーザーの操作が不明なので万が一「カートに入れた覚えのない商品が届いた！😡」というクレームに対して膨大なアクセスログを確認する羽目になります。
 
@@ -76,43 +76,43 @@ CRUD による State Sourcing ではユーザーの操作をデータの作成�
 
 1. 商品 A を1つカートに追加する
 
-   | EVENT ID | USER ID   | ITEM ID | EVENT NAME         |
-   | -------- | --------- | ------- | ------------------ |
-   | 1        | pyama2000 | A       | ItemAdded (NUM: 1) |
+   | EVENT ID | USER ID   | ITEM ID | EVENT NAME              |
+   | -------- | --------- | ------- | ----------------------- |
+   | 1        | pyama2000 | A       | ItemAdded (QUANTITY: 1) |
 
 2. 商品 B を1つカートに追加する
 
-   | EVENT ID | USER ID   | ITEM ID | EVENT NAME         |
-   | -------- | --------- | ------- | ------------------ |
-   | 1        | pyama2000 | A       | ItemAdded (NUM: 1) |
-   | 2        | pyama2000 | B       | ItemAdded (NUM: 2) |
+   | EVENT ID | USER ID   | ITEM ID | EVENT NAME              |
+   | -------- | --------- | ------- | ----------------------- |
+   | 1        | pyama2000 | A       | ItemAdded (QUANTITY: 1) |
+   | 2        | pyama2000 | B       | ItemAdded (QUANTITY: 2) |
 
 3. 商品 C を1つカートに追加する
 
-   | EVENT ID | USER ID   | ITEM ID | EVENT NAME         |
-   | -------- | --------- | ------- | ------------------ |
-   | 1        | pyama2000 | A       | ItemAdded (NUM: 1) |
-   | 2        | pyama2000 | B       | ItemAdded (NUM: 2) |
-   | 3        | pyama2000 | C       | ItemAdded (NUM: 3) |
+   | EVENT ID | USER ID   | ITEM ID | EVENT NAME              |
+   | -------- | --------- | ------- | ----------------------- |
+   | 1        | pyama2000 | A       | ItemAdded (QUANTITY: 1) |
+   | 2        | pyama2000 | B       | ItemAdded (QUANTITY: 2) |
+   | 3        | pyama2000 | C       | ItemAdded (QUANTITY: 3) |
 
 4. 商品 A の注文数を5つに増やす
 
-   | EVENT ID | USER ID   | ITEM ID | EVENT NAME              |
-   | -------- | --------- | ------- | ----------------------- |
-   | 1        | pyama2000 | A       | ItemAdded (NUM: 1)      |
-   | 2        | pyama2000 | B       | ItemAdded (NUM: 2)      |
-   | 3        | pyama2000 | C       | ItemAdded (NUM: 3)      |
-   | 4        | pyama2000 | A       | ItemNumChanged (NUM: 5) |
+   | EVENT ID | USER ID   | ITEM ID | EVENT NAME                   |
+   | -------- | --------- | ------- | ---------------------------- |
+   | 1        | pyama2000 | A       | ItemAdded (QUANTITY: 1)      |
+   | 2        | pyama2000 | B       | ItemAdded (QUANTITY: 2)      |
+   | 3        | pyama2000 | C       | ItemAdded (QUANTITY: 3)      |
+   | 4        | pyama2000 | A       | ItemNumChanged (QUANTITY: 5) |
 
 5. 商品 C をカートから削除する
 
-   | EVENT ID | USER ID   | ITEM ID | EVENT NAME              |
-   | -------- | --------- | ------- | ----------------------- |
-   | 1        | pyama2000 | A       | ItemAdded (NUM: 1)      |
-   | 2        | pyama2000 | B       | ItemAdded (NUM: 2)      |
-   | 3        | pyama2000 | C       | ItemAdded (NUM: 3)      |
-   | 4        | pyama2000 | A       | ItemNumChanged (NUM: 5) |
-   | 5        | pyama2000 | C       | ItemDeleted             |
+   | EVENT ID | USER ID   | ITEM ID | EVENT NAME                   |
+   | -------- | --------- | ------- | ---------------------------- |
+   | 1        | pyama2000 | A       | ItemAdded (QUANTITY: 1)      |
+   | 2        | pyama2000 | B       | ItemAdded (QUANTITY: 2)      |
+   | 3        | pyama2000 | C       | ItemAdded (QUANTITY: 3)      |
+   | 4        | pyama2000 | A       | ItemNumChanged (QUANTITY: 5) |
+   | 5        | pyama2000 | C       | ItemDeleted                  |
 
 このようにユーザーが操作したイベントを記録し、一連のイベントからカートの状態を表現することができます。ユーザーの操作をイベントとして記録しているのでクレームへの対応に対しても説明がしやすいですし、バグだった場合は再現手順も容易です。
 


### PR DESCRIPTION
## Overview

## Features

- Changelog を追加する

## Fixes

- example-cqrs-event-store のコード変更に追従する
  - https://github.com/pyama2000/example-cqrs-event-store/pull/9
- State Sourcing と Event Sourcing の比較に利用する例で、数量を `NUM` から `QUANTITY` に変更する
